### PR TITLE
fix(ci): activer bundling Windows + bump v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ Toutes les modifications notables de GuideME Ramadan Edition sont documentées d
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/),
 et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
-## [1.1.1] - 2026-02-24
+## [1.1.2] - 2026-02-24
 
 ### Corrigé
 
-- **Release CI** — pin `tauri-action@v0.6.1` (fix espaces dans productName)
+- **Release CI** — pin `tauri-action@v0.6.1` + activer `bundle.active: true` (Tauri v2 défaut = false)
 - **CSS variables** — remplacement des couleurs hardcodées par des custom properties
 - **Commentaires** — traduction des commentaires anglais en français
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "myramadan",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myramadan"
-version = "1.1.1"
+version = "1.1.2"
 description = "GuideME - Ramadan Edition"
 authors = ["GuideME"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,10 @@
 {
   "productName": "GuideME - Ramadan",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "identifier": "com.guideme.ramadan",
   "bundle": {
+    "active": true,
+    "targets": ["nsis", "msi"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/modules/changelog.js
+++ b/src/modules/changelog.js
@@ -5,14 +5,14 @@
 
 import storage from './storage.js'
 
-const APP_VERSION = '1.1.1'
+const APP_VERSION = '1.1.2'
 
 const CHANGELOG_ENTRIES = [
   {
-    version: '1.1.1',
+    version: '1.1.2',
     date: '24 février 2026',
     changes: [
-      { type: 'fix', text: 'Correction du pipeline de release automatique' },
+      { type: 'fix', text: 'Correction du pipeline de release (bundling Windows)' },
       { type: 'fix', text: 'Couleurs CSS harmonisées (variables custom)' },
       { type: 'fix', text: 'Commentaires traduits en français' },
     ],


### PR DESCRIPTION
## Summary
- Activer `bundle.active: true` dans tauri.conf.json (Tauri v2 défaut = false)
- Ajouter `targets: ["nsis", "msi"]` explicitement
- Bump version 1.1.1 → 1.1.2

## Context
Le workflow release échouait avec "No artifacts were found" car le bundling n'était pas activé.
En Tauri v2, `bundle.active` est `false` par défaut (contrairement à v1).