### PR TITLE
feat: builds macOS et Linux cross-platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: write
+    outputs:
+      releaseId: ${{ steps.tauri.outputs.releaseId }}
     steps:
       - uses: actions/checkout@v6
 
@@ -80,6 +82,7 @@ jobs:
         run: npm install
 
       - name: Build and release
+        id: tauri
         uses: tauri-apps/tauri-action@v0.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -92,6 +95,123 @@ jobs:
           releaseBody: |
             ## GuideME Ramadan v__VERSION__
 
-            Téléchargez l'installer Windows ci-dessous pour installer l'application.
+            ### Téléchargements
+
+            | Plateforme | Fichier |
+            |-----------|---------|
+            | **Windows** | `.msi` ou `.exe` (NSIS) |
+            | **macOS** | `.dmg` (Universal: Intel + Apple Silicon) |
+            | **Linux** | `.deb` ou `.AppImage` |
+
+            > **macOS** : au premier lancement, clic droit → Ouvrir (app non signée).
+            > **Linux** : AppImage nécessite `chmod +x` avant exécution.
           releaseDraft: false
           prerelease: false
+
+  build-macos:
+    needs: [check-version, build-windows]
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Install Rust stable with targets
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Sync version to Tauri config
+        env:
+          VERSION: ${{ needs.check-version.outputs.version }}
+        run: |
+          # Update tauri.conf.json
+          node -e "
+            const fs = require('fs');
+            const version = process.env.VERSION;
+            const conf = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json','utf8'));
+            conf.version = version;
+            fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(conf, null, 2) + '\n');
+          "
+          # Update Cargo.toml (BSD sed on macOS)
+          sed -i '' "s/^version = \".*\"/version = \"$VERSION\"/" src-tauri/Cargo.toml
+          echo "Synced version to $VERSION"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build and attach to release
+        uses: tauri-apps/tauri-action@v0.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUG_REPORT_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          releaseId: ${{ needs.build-windows.outputs.releaseId }}
+          args: --target universal-apple-darwin
+
+  build-linux:
+    needs: [check-version, build-windows]
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Sync version to Tauri config
+        env:
+          VERSION: ${{ needs.check-version.outputs.version }}
+        run: |
+          # Update tauri.conf.json
+          node -e "
+            const fs = require('fs');
+            const version = process.env.VERSION;
+            const conf = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json','utf8'));
+            conf.version = version;
+            fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(conf, null, 2) + '\n');
+          "
+          # Update Cargo.toml
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" src-tauri/Cargo.toml
+          echo "Synced version to $VERSION"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build and attach to release
+        uses: tauri-apps/tauri-action@v0.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUG_REPORT_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          releaseId: ${{ needs.build-windows.outputs.releaseId }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Toutes les modifications notables de GuideME Ramadan Edition sont documentées d
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/),
 et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
+## [1.4.0] - 2026-02-25
+
+### Ajouté
+
+- **Builds macOS et Linux** — l'app est désormais disponible sur Windows, macOS et Linux
+- **macOS** — binaire universel (.dmg) Intel + Apple Silicon via `--target universal-apple-darwin`
+- **Linux** — packages .deb et .AppImage pour les distributions Debian/Ubuntu et autres
+- **CI/CD multi-plateforme** — jobs parallèles macOS et Linux dans le workflow de release GitHub Actions
+- **Auto-update multi-plateforme** — `latest.json` unifié couvre les 3 OS automatiquement
+
 ## [1.3.0] - 2026-02-25
 
 ### Ajouté

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "myramadan",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myramadan"
-version = "1.3.0"
+version = "1.4.0"
 description = "GuideME - Ramadan Edition"
 authors = ["GuideME"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,13 +1,10 @@
 {
   "productName": "GuideME - Ramadan",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "identifier": "com.guideme.ramadan",
   "bundle": {
     "active": true,
-    "targets": [
-      "nsis",
-      "msi"
-    ],
+    "targets": "all",
     "createUpdaterArtifacts": "v1Compatible",
     "icon": [
       "icons/32x32.png",

--- a/src/modules/changelog.js
+++ b/src/modules/changelog.js
@@ -5,9 +5,18 @@
 
 import storage from './storage.js'
 
-const APP_VERSION = '1.3.0'
+const APP_VERSION = '1.4.0'
 
 const CHANGELOG_ENTRIES = [
+  {
+    version: '1.4.0',
+    date: '25 février 2026',
+    changes: [
+      { type: 'feature', text: 'Builds macOS (.dmg) et Linux (.deb, .AppImage) — l\'app est désormais disponible sur les 3 plateformes' },
+      { type: 'feature', text: 'macOS : binaire universel Intel + Apple Silicon en un seul fichier' },
+      { type: 'feature', text: 'Auto-update multi-plateforme via latest.json unifié' },
+    ],
+  },
   {
     version: '1.3.0',
     date: '25 février 2026',


### PR DESCRIPTION
## Summary

- Ajout des jobs **build-macos** et **build-linux** au workflow `release.yml`, exécutés en parallèle après `build-windows`
- macOS : binaire universel Intel + Apple Silicon (`.dmg`) via `--target universal-apple-darwin`
- Linux : packages `.deb` et `.AppImage` sur `ubuntu-22.04` avec `libwebkit2gtk-4.1-dev`
- `bundle.targets` passé de `["nsis", "msi"]` à `"all"` dans `tauri.conf.json`
- Bump version `1.3.0` → `1.4.0` (5 fichiers synchronisés)
- Release body enrichi avec tableau des téléchargements 3 plateformes

## Architecture CI

```
check-version (ubuntu)
  └── build-windows (windows-latest)  ← crée la Release, output releaseId
       ├── build-macos (macos-latest)  ← attach artifacts via releaseId
       └── build-linux (ubuntu-22.04)  ← attach artifacts via releaseId
```

## Test plan

- [ ] Vérifier que le workflow YAML est valide (syntaxe GitHub Actions)
- [ ] Tester via `workflow_dispatch` ou merge sur `main` avec bump version
- [ ] Vérifier que les 3 jobs passent (Windows, macOS, Linux)
- [ ] Vérifier que la Release GitHub contient les artifacts des 3 plateformes
- [ ] Vérifier que `latest.json` contient `windows-x86_64`, `darwin-universal`, `linux-x86_64`