### PR TITLE
chore: bump release to 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Toutes les modifications notables de GuideME Ramadan Edition sont documentées d
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/),
 et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
+## [1.8.1] - 2026-05-22
+
+### Corrigé
+
+- **Dépendances de sécurité** — mise à jour de Tauri, Vite, Undici, rustls-webpki, tar, quinn-proto et rand pour résoudre les alertes Dependabot applicables
+
+### Amélioré
+
+- **CI GitHub** — suppression du workflow de review Claude automatique qui bloquait les PR Dependabot
+- **Release** — mise à jour de `tauri-action` et des schémas Tauri générés
+
 ## [1.8.0] - 2026-02-27
 
 ### Ajouté

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "myramadan",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "myramadan",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "myramadan",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "myramadan"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myramadan"
-version = "1.8.0"
+version = "1.8.1"
 description = "GuideME - Ramadan Edition"
 authors = ["GuideME"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "GuideME - Ramadan",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "identifier": "com.guideme.ramadan",
   "bundle": {
     "active": true,

--- a/src/modules/changelog.js
+++ b/src/modules/changelog.js
@@ -5,9 +5,18 @@
 
 import storage from './storage.js'
 
-const APP_VERSION = '1.8.0'
+const APP_VERSION = '1.8.1'
 
 const CHANGELOG_ENTRIES = [
+  {
+    version: '1.8.1',
+    date: '22 mai 2026',
+    changes: [
+      { type: 'fix', text: 'Dépendances de sécurité — mise à jour de Tauri, Vite, Undici, rustls-webpki, tar, quinn-proto et rand' },
+      { type: 'improvement', text: 'CI GitHub — suppression du workflow de review Claude automatique qui bloquait les PR Dependabot' },
+      { type: 'improvement', text: 'Release — mise à jour de tauri-action et des schémas Tauri générés' },
+    ],
+  },
   {
     version: '1.8.0',
     date: '27 février 2026',


### PR DESCRIPTION
## Résumé
- bump version to 1.8.1 in package, Tauri and changelog files
- document the dependency security updates and CI workflow cleanup from PR #44

## Vérifications
- npm audit
- npm test
- npm run build
- cargo check
- cargo check --locked

After merge, the Release workflow should trigger because package.json changes on main.