### PR TITLE
fix(updater): add automatic update checks and notifications

### DIFF
--- a/src/modules/updater.js
+++ b/src/modules/updater.js
@@ -5,17 +5,29 @@
  */
 
 import { check } from '@tauri-apps/plugin-updater'
+import {
+  isPermissionGranted,
+  requestPermission,
+  sendNotification,
+} from '@tauri-apps/plugin-notification'
 import { relaunch } from '@tauri-apps/plugin-process'
 import storage from './storage.js'
 import { isMobile } from './platform.js'
 
 // Intervalle de vérification automatique (4 heures en ms)
 const AUTO_CHECK_INTERVAL = 4 * 60 * 60 * 1000
-// Délai initial avant le premier check au démarrage (30 secondes)
-const STARTUP_DELAY = 30 * 1000
+// Délai court pour laisser l'interface se stabiliser avant le check au démarrage
+const STARTUP_DELAY = 3 * 1000
+const LAST_CHECK_KEY = 'updater_lastCheck'
+const DISMISSED_VERSION_KEY = 'updater_dismissedVersion'
+const NOTIFIED_VERSION_KEY = 'updater_notifiedVersion'
 
 // Mise à jour courante (objet retourné par check())
 let pendingUpdate = null
+let automaticCheckRunning = false
+let startupTimer = null
+let periodicTimer = null
+let toastVersionShown = null
 
 // --- Utilitaires DOM ---
 
@@ -75,6 +87,111 @@ function displayError(msg) {
   if (el) el.textContent = msg || 'Une erreur inattendue est survenue.'
 }
 
+function isUpdateAvailable(update) {
+  return Boolean(update && update.available !== false)
+}
+
+function displayReady(update) {
+  displayVersion(update?.version ? `v${update.version}` : '')
+  displayNotes(update?.body || null)
+  showState('ready')
+}
+
+function showUpdateToast(update) {
+  if (!update?.version || toastVersionShown === update.version) return
+
+  toastVersionShown = update.version
+
+  const existing = document.getElementById('updater-toast')
+  if (existing) existing.remove()
+
+  const toast = document.createElement('div')
+  toast.id = 'updater-toast'
+  toast.className = 'auto-select-toast updater-toast'
+
+  const icon = document.createElement('i')
+  icon.className = 'fa-solid fa-download'
+  toast.appendChild(icon)
+
+  const textContainer = document.createElement('div')
+  textContainer.className = 'auto-select-toast-text'
+
+  const title = document.createElement('div')
+  title.className = 'auto-select-toast-title'
+  title.textContent = 'Mise à jour disponible'
+  textContainer.appendChild(title)
+
+  const subtitle = document.createElement('div')
+  subtitle.className = 'auto-select-toast-subtitle'
+  subtitle.textContent = `GuideME v${update.version} est prêt à installer`
+  textContainer.appendChild(subtitle)
+
+  toast.appendChild(textContainer)
+
+  const openBtn = document.createElement('button')
+  openBtn.className = 'auto-select-toast-btn'
+  openBtn.textContent = 'Voir'
+  openBtn.addEventListener('click', () => {
+    toast.remove()
+    openModal()
+    displayReady(update)
+  })
+  toast.appendChild(openBtn)
+
+  const closeBtn = document.createElement('button')
+  closeBtn.className = 'auto-select-toast-close'
+  const closeIcon = document.createElement('i')
+  closeIcon.className = 'fa-solid fa-xmark'
+  closeBtn.appendChild(closeIcon)
+  closeBtn.addEventListener('click', () => {
+    toast.classList.add('toast-exit')
+    setTimeout(() => toast.remove(), 300)
+  })
+  toast.appendChild(closeBtn)
+
+  document.body.appendChild(toast)
+  requestAnimationFrame(() => toast.classList.add('toast-visible'))
+
+  setTimeout(() => {
+    if (toast.parentNode) {
+      toast.classList.add('toast-exit')
+      setTimeout(() => toast.remove(), 300)
+    }
+  }, 10000)
+}
+
+async function ensureNotificationPermission() {
+  try {
+    let granted = await isPermissionGranted()
+    if (!granted) {
+      const result = await requestPermission()
+      granted = result === 'granted'
+    }
+    return granted
+  } catch (err) {
+    console.warn('[updater] Permission notification indisponible :', err)
+    return false
+  }
+}
+
+async function notifyUpdateReady(update) {
+  if (!update?.version) return
+  if (storage.get(NOTIFIED_VERSION_KEY) === update.version) return
+
+  const granted = await ensureNotificationPermission()
+  if (!granted) return
+
+  try {
+    sendNotification({
+      title: 'Mise à jour GuideME disponible',
+      body: `La version ${update.version} est prête à installer.`,
+    })
+    storage.set(NOTIFIED_VERSION_KEY, update.version)
+  } catch (err) {
+    console.warn('[updater] Notification de mise à jour échouée :', err)
+  }
+}
+
 // --- Logique principale ---
 
 /**
@@ -83,27 +200,29 @@ function displayError(msg) {
  * Respecte la version ignorée par l'utilisateur.
  */
 async function silentCheck() {
+  if (automaticCheckRunning) return
+  automaticCheckRunning = true
+
   try {
-    storage.set('updater_lastCheck', Date.now())
+    storage.set(LAST_CHECK_KEY, Date.now())
     const update = await check()
 
-    if (!update || !update.available) {
+    if (!isUpdateAvailable(update)) {
       // Pas de mise à jour disponible
       pendingUpdate = null
+      hideBadge()
       return
     }
 
     // Vérifier si l'utilisateur a ignoré cette version
-    const dismissed = storage.get('updater_dismissedVersion')
+    const dismissed = storage.get(DISMISSED_VERSION_KEY)
     if (dismissed && dismissed === update.version) {
+      pendingUpdate = null
+      hideBadge()
       return
     }
 
-    // Téléchargement en arrière-plan avec suivi de progression
-    pendingUpdate = update
-    showBadge()
-
-    // Pré-téléchargement silencieux
+    // Pré-téléchargement silencieux : la mise à jour devient actionnable seulement après.
     await update.download((event) => {
       // Les événements de progression sont optionnels — on les ignore en mode silencieux
       if (event.event === 'Started') {
@@ -111,10 +230,17 @@ async function silentCheck() {
       }
     })
 
+    pendingUpdate = update
+    showBadge()
     console.log('[updater] Mise à jour', update.version, 'prête à installer')
+    displayReady(update)
+    showUpdateToast(update)
+    await notifyUpdateReady(update)
   } catch (err) {
     // En mode dev le plugin updater peut ne pas être disponible — on ignore silencieusement
     console.warn('[updater] Check silencieux échoué :', err)
+  } finally {
+    automaticCheckRunning = false
   }
 }
 
@@ -128,15 +254,16 @@ async function manualCheck() {
   setProgress(0, '0%')
 
   try {
-    storage.set('updater_lastCheck', Date.now())
+    storage.set(LAST_CHECK_KEY, Date.now())
 
     // Petite pause visuelle pour que l'état "checking" soit perçu
     await new Promise(resolve => setTimeout(resolve, 600))
 
     const update = await check()
 
-    if (!update || !update.available) {
+    if (!isUpdateAvailable(update)) {
       pendingUpdate = null
+      hideBadge()
       showState('uptodate')
       return
     }
@@ -145,7 +272,7 @@ async function manualCheck() {
 
     // Si déjà pré-téléchargé en mode silencieux, afficher directement "ready"
     // Sinon, télécharger maintenant avec progression visible
-    const dismissed = storage.get('updater_dismissedVersion')
+    const dismissed = storage.get(DISMISSED_VERSION_KEY)
     if (dismissed && dismissed === update.version) {
       // L'utilisateur a ignoré cette version mais a relancé un check manuel — on la propose quand même
     }
@@ -171,9 +298,7 @@ async function manualCheck() {
 
     // Prêt à installer
     showBadge()
-    displayVersion(`v${update.version}`)
-    displayNotes(update.body || null)
-    showState('ready')
+    displayReady(update)
   } catch (err) {
     console.error('[updater] Check manuel échoué :', err)
     displayError(err?.message || String(err))
@@ -195,6 +320,11 @@ export async function initUpdater() {
   if (btn) {
     btn.addEventListener('click', (e) => {
       e.preventDefault()
+      if (pendingUpdate) {
+        openModal()
+        displayReady(pendingUpdate)
+        return
+      }
       manualCheck()
     })
   }
@@ -229,8 +359,10 @@ export async function initUpdater() {
   if (laterBtn) {
     laterBtn.addEventListener('click', async () => {
       if (pendingUpdate) {
-        storage.set('updater_dismissedVersion', pendingUpdate.version)
+        storage.set(DISMISSED_VERSION_KEY, pendingUpdate.version)
       }
+      pendingUpdate = null
+      document.getElementById('updater-toast')?.remove()
       hideBadge()
       closeModal()
     })
@@ -252,11 +384,13 @@ export async function initUpdater() {
   const closeUptodateBtn = document.getElementById('updater-close-uptodate')
   if (closeUptodateBtn) closeUptodateBtn.addEventListener('click', closeModal)
 
-  // Check automatique au démarrage (délai 30s)
-  setTimeout(async () => {
-    await silentCheck()
+  // Check automatique au démarrage, puis toutes les 4 heures.
+  if (startupTimer) clearTimeout(startupTimer)
+  if (periodicTimer) clearInterval(periodicTimer)
 
-    // Puis toutes les 4 heures
-    setInterval(silentCheck, AUTO_CHECK_INTERVAL)
+  startupTimer = setTimeout(() => {
+    silentCheck()
   }, STARTUP_DELAY)
+
+  periodicTimer = setInterval(silentCheck, AUTO_CHECK_INTERVAL)
 }

--- a/src/modules/updater.test.js
+++ b/src/modules/updater.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('@tauri-apps/plugin-updater', () => ({
+  check: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/plugin-notification', () => ({
+  isPermissionGranted: vi.fn(),
+  requestPermission: vi.fn(),
+  sendNotification: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/plugin-process', () => ({
+  relaunch: vi.fn(),
+}))
+
+vi.mock('./platform.js', () => ({
+  isMobile: false,
+}))
+
+vi.mock('./storage.js')
+
+const STARTUP_DELAY = 3 * 1000
+const AUTO_CHECK_INTERVAL = 4 * 60 * 60 * 1000
+
+function setupUpdaterDom() {
+  document.body.innerHTML = `
+    <a href="#" id="updater-btn"><span id="updater-badge" style="display: none;">NEW</span></a>
+    <div id="updater-modal" class="hidden">
+      <div id="updater-state-checking"></div>
+      <div id="updater-state-ready" class="hidden"></div>
+      <div id="updater-state-error" class="hidden"></div>
+      <div id="updater-state-uptodate" class="hidden"></div>
+      <div id="updater-progress-fill"></div>
+      <div id="updater-progress-text"></div>
+      <div id="updater-version"></div>
+      <div id="updater-notes"></div>
+      <div id="updater-error-msg"></div>
+      <button id="updater-close"></button>
+      <button id="updater-install-btn"></button>
+      <button id="updater-later-btn"></button>
+      <button id="updater-retry-btn"></button>
+      <button id="updater-close-error"></button>
+      <button id="updater-close-uptodate"></button>
+    </div>
+  `
+}
+
+function makeUpdate(version = '1.9.0') {
+  return {
+    version,
+    body: 'Notes de version',
+    download: vi.fn(async (onEvent) => {
+      onEvent({ event: 'Started', data: { contentLength: 10 } })
+      onEvent({ event: 'Finished', data: {} })
+    }),
+    install: vi.fn(),
+  }
+}
+
+async function loadUpdater() {
+  vi.resetModules()
+  const updater = await import('./updater.js')
+  const updaterPlugin = await import('@tauri-apps/plugin-updater')
+  const notifications = await import('@tauri-apps/plugin-notification')
+  const storage = await import('./storage.js')
+  updaterPlugin.check.mockReset()
+  notifications.isPermissionGranted.mockReset()
+  notifications.requestPermission.mockReset()
+  notifications.sendNotification.mockReset()
+  return { updater, updaterPlugin, notifications, storage: storage.default }
+}
+
+describe('updater', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('requestAnimationFrame', (callback) => {
+      callback()
+      return 1
+    })
+    setupUpdaterDom()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('runs a startup check and treats a Tauri v2 Update object as available', async () => {
+    const { updater, updaterPlugin, notifications, storage } = await loadUpdater()
+    const update = makeUpdate()
+    storage._reset()
+    updaterPlugin.check.mockResolvedValue(update)
+    notifications.isPermissionGranted.mockResolvedValue(true)
+
+    await updater.initUpdater()
+    await vi.advanceTimersByTimeAsync(STARTUP_DELAY)
+
+    expect(updaterPlugin.check).toHaveBeenCalledTimes(1)
+    expect(update.download).toHaveBeenCalledTimes(1)
+    expect(document.getElementById('updater-badge').style.display).toBe('')
+    expect(document.getElementById('updater-version').textContent).toBe('v1.9.0')
+    expect(document.getElementById('updater-state-ready').classList.contains('hidden')).toBe(false)
+    expect(document.getElementById('updater-toast')).not.toBeNull()
+    expect(notifications.sendNotification).toHaveBeenCalledWith({
+      title: 'Mise à jour GuideME disponible',
+      body: 'La version 1.9.0 est prête à installer.',
+    })
+  })
+
+  it('checks again on the periodic interval', async () => {
+    const { updater, updaterPlugin, storage } = await loadUpdater()
+    storage._reset()
+    updaterPlugin.check.mockResolvedValue(null)
+
+    await updater.initUpdater()
+    await vi.advanceTimersByTimeAsync(STARTUP_DELAY)
+    await vi.advanceTimersByTimeAsync(AUTO_CHECK_INTERVAL)
+
+    expect(updaterPlugin.check).toHaveBeenCalledTimes(2)
+    expect(document.getElementById('updater-badge').style.display).toBe('none')
+  })
+
+  it('opens the ready state without rechecking when an update is already pending', async () => {
+    const { updater, updaterPlugin, notifications, storage } = await loadUpdater()
+    const update = makeUpdate()
+    storage._reset()
+    updaterPlugin.check.mockResolvedValue(update)
+    notifications.isPermissionGranted.mockResolvedValue(true)
+
+    await updater.initUpdater()
+    await vi.advanceTimersByTimeAsync(STARTUP_DELAY)
+
+    document.getElementById('updater-btn').click()
+
+    expect(updaterPlugin.check).toHaveBeenCalledTimes(1)
+    expect(document.getElementById('updater-modal').classList.contains('hidden')).toBe(false)
+    expect(document.getElementById('updater-state-ready').classList.contains('hidden')).toBe(false)
+  })
+
+  it('clears the pending update when the user chooses later', async () => {
+    const { updater, updaterPlugin, notifications, storage } = await loadUpdater()
+    const update = makeUpdate()
+    storage._reset()
+    updaterPlugin.check.mockResolvedValue(update)
+    notifications.isPermissionGranted.mockResolvedValue(true)
+
+    await updater.initUpdater()
+    await vi.advanceTimersByTimeAsync(STARTUP_DELAY)
+
+    document.getElementById('updater-later-btn').click()
+    expect(storage.get('updater_dismissedVersion')).toBe('1.9.0')
+    expect(document.getElementById('updater-badge').style.display).toBe('none')
+    expect(document.getElementById('updater-toast')).toBeNull()
+
+    document.getElementById('updater-btn').click()
+    await vi.advanceTimersByTimeAsync(600)
+
+    expect(updaterPlugin.check).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not notify again for a dismissed version', async () => {
+    const { updater, updaterPlugin, notifications, storage } = await loadUpdater()
+    const update = makeUpdate()
+    storage._reset()
+    storage.set('updater_dismissedVersion', '1.9.0')
+    updaterPlugin.check.mockResolvedValue(update)
+
+    await updater.initUpdater()
+    await vi.advanceTimersByTimeAsync(STARTUP_DELAY)
+
+    expect(update.download).not.toHaveBeenCalled()
+    expect(document.getElementById('updater-badge').style.display).toBe('none')
+    expect(notifications.sendNotification).not.toHaveBeenCalled()
+  })
+})

--- a/src/style.css
+++ b/src/style.css
@@ -2774,6 +2774,15 @@ body {
     font-size: 1.2rem;
 }
 
+.auto-select-toast.updater-toast {
+    border-color: var(--clr-gold);
+}
+
+.auto-select-toast.updater-toast .fa-download {
+    color: var(--clr-gold);
+    font-size: 1.2rem;
+}
+
 .auto-select-toast.toast-visible {
     opacity: 1;
     transform: translateX(-50%) translateY(0);


### PR DESCRIPTION
## Summary
Improves the desktop updater flow so GuideME checks for updates automatically and visibly notifies users when an update is ready.

## Changes
- Fixed Tauri v2 update detection by treating a returned `Update` object as available
- Added startup and recurring silent checks for desktop builds
- Added native update notifications plus an in-app toast that opens the updater modal
- Kept manual checks available from the sidebar and fixed the `Plus tard` dismissal flow
- Added focused Vitest coverage for startup checks, periodic checks, pending updates, notifications, and dismissed versions

## Tests
- `npm test`
- `npm run build`
- `npm run tauri -- build --debug` compiled the app and generated debug bundles, then stopped at updater signing because `TAURI_SIGNING_PRIVATE_KEY` is not available in this worktree

## Notes
The current public updater manifest points to `1.8.1` while this checkout is `1.8.2`, so a real `1.8.2` install should not show an update until a newer release is published.
